### PR TITLE
RSS is not the correct capitalization at this point.

### DIFF
--- a/src/Vinelab/Rss/RssServiceProvider.php
+++ b/src/Vinelab/Rss/RssServiceProvider.php
@@ -21,7 +21,7 @@ class RssServiceProvider extends ServiceProvider
         $this->app->register('Vinelab\Http\HttpServiceProvider');
 
         $this->app->bind('vinelab.rss', function ($app) {
-            return new RSS($app->make('Vinelab\Rss\Parsers\XML'),
+            return new Rss($app->make('Vinelab\Rss\Parsers\XML'),
                             $app->make('Vinelab\Http\Client'));
         });
 


### PR DESCRIPTION
It works on my local mac, homestead which have a known caps are off setting, but on Codeship and DigitalOcean/Forge deployment it breaks.