### PR TITLE
fix where RSS feed only has a single item

### DIFF
--- a/src/Vinelab/Rss/Feed.php
+++ b/src/Vinelab/Rss/Feed.php
@@ -55,8 +55,12 @@ class Feed implements Contracts\FeedInterface
     {
         $this->articles = new ArticlesCollection();
 
-        foreach ($channel['item'] as $entry) {
-            $this->addArticle($entry);
+        if(is_array($channel['item'])){
+            foreach ($channel['item'] as $entry) {
+                $this->addArticle($entry);
+            }
+        }else{
+            $this->addArticle($channel['item']);
         }
     }
 


### PR DESCRIPTION
If an RSS feed only has a single item the foreach loops through it's properties and adds an empty article for each