### PR TITLE
added __isset to access dynamic properties in twig

### DIFF
--- a/src/Vinelab/Rss/Article.php
+++ b/src/Vinelab/Rss/Article.php
@@ -46,4 +46,16 @@ class Article
     {
         return isset($this->info[$element]) ? $this->info[$element] : null;
     }
+    
+    /**
+     * A gateway to check for the data stored in $info.
+     *
+     * @param string $element
+     *
+     * @return bool
+     */
+    public function __isset($element)
+    {
+        return array_key_exists($element, $this->info);
+    }
 }


### PR DESCRIPTION
Twig is not able to access dynamic properties without __isset
ref http://twig.sensiolabs.org/doc/recipes.html#using-dynamic-object-properties
