### PR TITLE
Extend article access

### DIFF
--- a/src/Vinelab/Rss/Article.php
+++ b/src/Vinelab/Rss/Article.php
@@ -19,7 +19,13 @@ class Article
     public function __construct($article)
     {
         foreach ($article as $attribute => $value) {
-            $this->info[$attribute] = (string) $value;
+            // for enclosure, get the attributes as array
+            if ($attribute == 'enclosure')
+                $value = current($value->attributes());
+            else
+                $value = (string) $value;
+
+            $this->info[$attribute] = $value;
         }
     }
 

--- a/src/Vinelab/Rss/Article.php
+++ b/src/Vinelab/Rss/Article.php
@@ -5,6 +5,13 @@ namespace Vinelab\Rss;
 class Article
 {
     /**
+     * Holds the original SimpleXMLElement
+     *
+     * @var SimpleXMLElement
+     */
+    protected $element = null;
+
+    /**
      * Holds the article information.
      *
      * @var array
@@ -18,6 +25,8 @@ class Article
      */
     public function __construct($article)
     {
+        $this->element = $article;
+
         foreach ($article as $attribute => $value) {
             // for enclosure, get the attributes as array
             if ($attribute == 'enclosure')
@@ -39,6 +48,16 @@ class Article
     public static function make($article)
     {
         return new static($article);
+    }
+
+    /**
+     * Get the original SimpleXMLElement
+     *
+     * @return SimpleXMLElement
+     */
+    public function getElement()
+    {
+        return $this->element;
     }
 
     /**


### PR DESCRIPTION
- Add support for getting the `enclosure` attribute, its value is defined by its attributes
- Allow the user to access the original SimpleXMLElement item, this allows you to get more advanced attributes like `media:content` nodes

Resolves #10 