### PR TITLE
Fix return type on Rss::fetch

### DIFF
--- a/src/Vinelab/Rss/Rss.php
+++ b/src/Vinelab/Rss/Rss.php
@@ -44,9 +44,9 @@ class Rss
      * @param string $url
      * @param string $format
      *
-     * @return ArticlesCollection
+     * @return FeedInterface
      */
-    public function feed($url, $format = 'xml') : ArticlesCollection
+    public function feed($url, $format = 'xml') : FeedInterface
     {
         return $this->parse($this->fetch($url), $format);
     }


### PR DESCRIPTION
The doc block and return type suggest it's returning an ArticlesCollection but in reality it's returning the output of `parse()`, which is returning an instance of the `FeedInterface`, so any usage of this method just returns an exception.

Thanks for the great library!