### PR TITLE
Add support for Laravel 9.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,12 +10,12 @@
     ],
     "require": {
         "php": ">=7.1",
-        "illuminate/support": "~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0|^7.0|^8.0",
+        "illuminate/support": "~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0|^7.0|^8.0|^9.0",
         "vinelab/http": "*",
         "ext-simplexml": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "7.*.*",
+        "phpunit/phpunit": "7.*.*|8.*|9.*",
         "mockery/mockery": "0.9.*"
     },
     "autoload": {


### PR DESCRIPTION
Update `illuminate/support` constraint to support Laravel 9.x.

I have also allowed `phpunit/phpunit` 8.x and 9.x, seeing as there are no breaking changes in the test suite.
